### PR TITLE
Fix missing nationality bug

### DIFF
--- a/basketball_reference_scraper/teams.py
+++ b/basketball_reference_scraper/teams.py
@@ -20,7 +20,7 @@ def get_roster(team, season_end_year):
                         'NATIONALITY', 'EXPERIENCE', 'COLLEGE']
         df['PLAYER'] = df['PLAYER'].apply(lambda name: remove_accents(name, team, season_end_year))
         df['BIRTH_DATE'] = df['BIRTH_DATE'].apply(lambda x: pd.to_datetime(x))
-        df['NATIONALITY'] = df['NATIONALITY'].apply(lambda x: x.upper())
+        df['NATIONALITY'] = df['NATIONALITY'].str.upper()
     return df
 
 def get_team_stats(team, season_end_year, data_format='PER_GAME'):

--- a/test/test_teams.py
+++ b/test/test_teams.py
@@ -12,6 +12,14 @@ class TestTeams(unittest.TestCase):
 
         self.assertListEqual(list(df.columns), expected_columns) 
 
+    def test_get_roster_on_missing_nationality(self):
+        df = get_roster('FTW', 1956)
+
+        expected_columns = ['NUMBER', 'PLAYER', 'POS', 'HEIGHT', 'WEIGHT',
+                'BIRTH_DATE', 'NATIONALITY', 'EXPERIENCE', 'COLLEGE']
+
+        self.assertListEqual(list(df.columns), expected_columns)
+
     def get_team_stats(self):
         series = get_team_stats('GSW', 2019)
         expected_indices = ['G', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']


### PR DESCRIPTION
This PR resolves #27 by using the built-in `pd.DataFrame.str.upper` method instead of the `lambda` function that failed on null values.

I also added a new test, `test_get_roster_on_missing_nationality`, that tests on a [page known to be missing a nationality value](https://www.basketball-reference.com/teams/FTW/1956.html) for one player.