### PR TITLE
Add ask_matches parameter to get_game_logs

### DIFF
--- a/basketball_reference_scraper/lookup.py
+++ b/basketball_reference_scraper/lookup.py
@@ -52,6 +52,8 @@ def lookup(player, ask_matches = True):
     if len(matches) == 1 or ask_matches == False:
         print("You searched for \"{}\"\n{} result found.\n{}".format(player, len(matches), matches[0][0]))
         print("Results for {}:\n".format(matches[0][0]))
+        if len(matches) > 1:
+            matches.sort(key=lambda tup: tup[1])
         return matches[0][0]
 
     elif len(matches) > 1:

--- a/basketball_reference_scraper/lookup.py
+++ b/basketball_reference_scraper/lookup.py
@@ -50,10 +50,10 @@ def lookup(player, ask_matches = True):
         the user to confirm specifiy their selection.
     """
     if len(matches) == 1 or ask_matches == False:
-        print("You searched for \"{}\"\n{} result found.\n{}".format(player, len(matches), matches[0][0]))
-        print("Results for {}:\n".format(matches[0][0]))
         if len(matches) > 1:
             matches.sort(key=lambda tup: tup[1])
+        print("You searched for \"{}\"\n{} result found.\n{}".format(player, len(matches), matches[0][0]))
+        print("Results for {}:\n".format(matches[0][0]))
         return matches[0][0]
 
     elif len(matches) > 1:

--- a/basketball_reference_scraper/lookup.py
+++ b/basketball_reference_scraper/lookup.py
@@ -50,8 +50,7 @@ def lookup(player, ask_matches = True):
         the user to confirm specifiy their selection.
     """
     if len(matches) == 1 or ask_matches == False:
-        if len(matches) > 1:
-            matches.sort(key=lambda tup: tup[1])
+        matches.sort(key=lambda tup: tup[1])
         print("You searched for \"{}\"\n{} result found.\n{}".format(player, len(matches), matches[0][0]))
         print("Results for {}:\n".format(matches[0][0]))
         return matches[0][0]

--- a/basketball_reference_scraper/players.py
+++ b/basketball_reference_scraper/players.py
@@ -38,8 +38,8 @@ def get_stats(_name, stat_type='PER_GAME', playoffs=False, career=False, ask_mat
         df = df.reset_index().drop('index', axis=1)
         return df
 
-def get_game_logs(_name, start_date, end_date, playoffs=False):
-    name = lookup(_name)
+def get_game_logs(_name, start_date, end_date, playoffs=False, ask_matches=True):
+    name = lookup(_name, ask_matches)
     suffix = get_player_suffix(name).replace('/', '%2F').replace('.html', '')
     start_date_str = start_date
     end_date_str = end_date

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="basketball_reference_scraper",
-    version="1.0.26",
+    version="1.0.27",
     author="Vishaal Agartha",
     author_email="vishaalagartha@gmail.com",
     license="MIT",


### PR DESCRIPTION
Surfacing the `ask_matches` parameter from the `lookup` function for use when getting game logs. This is in line with what's already been done on the `get_stats` function.

Added a sort in `lookup` function to address [this issue](https://github.com/vishaalagartha/basketball_reference_scraper/issues/42)