### PR TITLE
Resolve issue with 1971 and 1953 seasons

### DIFF
--- a/basketball_reference_scraper/seasons.py
+++ b/basketball_reference_scraper/seasons.py
@@ -15,8 +15,9 @@ def get_schedule(season, playoffs=False):
         if r.status_code==200:
             soup = BeautifulSoup(r.content, 'html.parser')
             table = soup.find('table', attrs={'id': 'schedule'})
-            month_df = pd.read_html(str(table))[0]
-            df = df.append(month_df)
+            if table:
+                month_df = pd.read_html(str(table))[0]
+                df = df.append(month_df)
     df = df.reset_index()
     cols_to_remove = [i for i in df.columns if 'Unnamed' in i]
     cols_to_remove += [i for i in df.columns if 'Notes' in i]

--- a/basketball_reference_scraper/seasons.py
+++ b/basketball_reference_scraper/seasons.py
@@ -41,6 +41,9 @@ def get_schedule(season, playoffs=False):
         else:
             df = df[:playoff_index]
     else:
+        # account for 1953 season where there's more than one "playoffs" header
+        if season == 1953:
+            df.drop_duplicates(subset=['DATE', 'HOME', 'VISITOR'], inplace=True)
         playoff_loc = df[df['DATE']=='Playoffs']
         if len(playoff_loc.index)>0:
             playoff_index = playoff_loc.index[0]

--- a/test/test_seasons.py
+++ b/test/test_seasons.py
@@ -8,6 +8,13 @@ class TestSeason(unittest.TestCase):
                 'HOME_PTS']
         self.assertListEqual(list(df.columns), expected_columns)
 
+    def test_get_schedule_weird_season(self):
+        for season in (1971, 1953):
+            cur_season = get_schedule(season)
+            expected_columns = ['DATE', 'VISITOR', 'VISITOR_PTS', 'HOME',
+                    'HOME_PTS']
+            self.assertListEqual(list(cur_season.columns), expected_columns)
+
     def test_get_standings(self):
         d = get_standings()
         self.assertListEqual(list(d.keys()), ['EASTERN_CONF', 'WESTERN_CONF'])
@@ -15,6 +22,15 @@ class TestSeason(unittest.TestCase):
         df = d['WESTERN_CONF']
         expected_columns = ['TEAM', 'W', 'L', 'W/L%', 'GB', 'PW', 'PL', 'PS/G', 'PA/G']
         self.assertListEqual(list(df.columns), expected_columns)
+
+    def test_get_standings_weird_season(self):
+        for season in (1971, 1953):
+            d = get_standings(season)
+            self.assertListEqual(list(d.keys()), ['EASTERN_CONF', 'WESTERN_CONF'])
+
+            df = d['WESTERN_CONF']
+            expected_columns = ['TEAM', 'W', 'L', 'W/L%', 'GB', 'PW', 'PL', 'PS/G', 'PA/G']
+            self.assertListEqual(list(df.columns), expected_columns)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_seasons.py
+++ b/test/test_seasons.py
@@ -10,10 +10,11 @@ class TestSeason(unittest.TestCase):
 
     def test_get_schedule_weird_season(self):
         for season in (1971, 1953):
-            cur_season = get_schedule(season)
-            expected_columns = ['DATE', 'VISITOR', 'VISITOR_PTS', 'HOME',
-                    'HOME_PTS']
-            self.assertListEqual(list(cur_season.columns), expected_columns)
+            for use_playoffs in (True, False):
+                cur_season = get_schedule(season, playoffs=use_playoffs)
+                expected_columns = ['DATE', 'VISITOR', 'VISITOR_PTS', 'HOME',
+                        'HOME_PTS']
+                self.assertListEqual(list(cur_season.columns), expected_columns)
 
     def test_get_standings(self):
         d = get_standings()


### PR DESCRIPTION
Original issue here https://github.com/vishaalagartha/basketball_reference_scraper/issues/44

For 1953 playoffs, there are two playoffs headers for some reason (https://www.basketball-reference.com/leagues/NBA_1953_games-march.html) so you have to drop the first one otherwise you get a date parse error.

For 1971, there's a weird phantom page (https://www.basketball-reference.com/leagues/NBA_1971_games-may.html) with no table for may, so you just have to check whether the table scraped from beautifulsoup is `None` before doing any operations with it

I added testing for each of these edge case seasons and their playoffs