### PR TITLE
Feature: Box score for NBA All Star Games

### DIFF
--- a/API.md
+++ b/API.md
@@ -194,6 +194,20 @@ Returns:
   >>> list(d['ATL'].columns)
   ['PLAYER', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS', '+/-']
   ```
+### `get_all_star_box_score(year: int)`
+
+Parameters:
+  - `year` - End year of game in which all-star season ocurred e.g. 2020 for the 2019-20 ASG 
+
+Returns:
+
+  A dictionary containing relevant stats for each team as a Pandas DataFrame. For example:
+
+  ```
+  >>> d = get_all_star_box_score(2020)
+  >>> list(d['Team Lebron'].columns)
+  ['PLAYER', 'TEAM', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
+  ```
 
 ## Play-by-play
 

--- a/basketball_reference_scraper/box_scores.py
+++ b/basketball_reference_scraper/box_scores.py
@@ -2,6 +2,7 @@ import pandas as pd
 from requests import get
 from bs4 import BeautifulSoup
 from datetime import datetime
+from unidecode import unidecode
 import re
 
 try:
@@ -16,24 +17,34 @@ def get_box_scores(date, team1, team2, period='GAME', stat_type='BASIC'):
     suffix = get_game_suffix(date, team1, team2).replace('/', '%2F')
     r1 = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_box-{team1}-{period.lower()}-{stat_type.lower()}')
     r2 = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_box-{team2}-{period.lower()}-{stat_type.lower()}')
+    dfs = []
     if r1.status_code==200 and r2.status_code==200:
-        soup = BeautifulSoup(r1.content, 'html.parser')
-        table = soup.find('table')
-        df1 = pd.read_html(str(table))[0]
-        df1.columns = list(map(lambda x: x[1], list(df1.columns)))
-        df1.rename(columns = {'Starters': 'PLAYER'}, inplace=True)
-        df1['PLAYER'] = df1['PLAYER'].apply(lambda name: remove_accents(name, team1, date.year))
-        reserve_index = df1[df1['PLAYER']=='Reserves'].index[0]
-        df1 = df1.drop(reserve_index).reset_index().drop('index', axis=1)
-        soup = BeautifulSoup(r2.content, 'html.parser')
-        table = soup.find('table')
-        df2 = pd.read_html(str(table))[0]
-        df2.columns = list(map(lambda x: x[1], list(df2.columns)))
-        df2.rename(columns = {'Starters': 'PLAYER'}, inplace=True)
-        df2['PLAYER'] = df2['PLAYER'].apply(lambda name: remove_accents(name, team2, date.year))
-        reserve_index = df2[df2['PLAYER']=='Reserves'].index[0]
-        df2 = df2.drop(reserve_index).reset_index().drop('index', axis=1)
-        return {team1: df1, team2: df2}
+        for rq in (r1, r2):
+            soup = BeautifulSoup(rq.content, 'html.parser')
+            table = soup.find('table')
+            raw_df = pd.read_html(str(table))[0]
+            df = _process_box(raw_df)
+            df['PLAYER'] = df['PLAYER'].apply(lambda name: remove_accents(name, team1, date.year))
+            dfs.append(df)
+        return {team1: dfs[0], team2: dfs[1]}
+
+def _process_box(df):
+    """ Perform basic processing on a box score - common to both methods
+
+    Args:
+        df (DataFrame): the raw box score df
+
+    Returns:
+        DataFrame: processed box score
+    """
+    df.columns = list(map(lambda x: x[1], list(df.columns)))
+    df.rename(columns = {'Starters': 'PLAYER'}, inplace=True)
+    if 'Tm' in df:
+        df.rename(columns = {'Tm': 'TEAM'}, inplace=True)
+    reserve_index = df[df['PLAYER']=='Reserves'].index[0]
+    df = df.drop(reserve_index).reset_index().drop('index', axis=1) 
+    return df
+
 
 def get_all_star_box_score(year: int):
     """ Returns box star for all star game in a given year
@@ -56,16 +67,13 @@ def get_all_star_box_score(year: int):
         soup = BeautifulSoup(r.content, 'html.parser')
         team_names = list(map(lambda el: el.text, soup.select('div.section_heading > h2')[1:3]))
         for table in soup.find_all('table')[1:3]:
-            df = pd.read_html(str(table))[0]
-            df.columns = list(map(lambda x: x[1], list(df.columns)))
-            df.rename(columns = {'Starters': 'PLAYER', 'Tm': 'TEAM'}, inplace=True)
-            reserve_index = df[df['PLAYER']=='Reserves'].index[0]
-            df = df.drop(reserve_index).reset_index().drop('index', axis=1) 
+            raw_df = pd.read_html(str(table))[0]
+            df = _process_box(raw_df)
             #drop team totals row (always last), totals row
             totals_index = df[df['MP'] == 'Totals'].index[0]
             df = df.drop(totals_index).reset_index().drop('index', axis=1) 
             df = df.drop(df.tail(1).index).reset_index().drop('index', axis=1) 
-            # sometimes there is a nan player
+            df['PLAYER'] = df['PLAYER'].apply(lambda x: unidecode(x))
             dfs.append(df)
         res = {team_names[0]: dfs[0], team_names[1]: dfs[1]}
         # add DNPs for all-star roster purposes
@@ -76,12 +84,10 @@ def get_all_star_box_score(year: int):
             # listed twice (e.g. 1980)
             as_team = dnp_allstar_teams[i]
             if dnp not in res[as_team]['PLAYER'].values:
-                new_row = {col: 0 for col in df.columns if col != 'PLAYER' and col != 'TEAM'}
-                new_row['PLAYER'] = dnp
                 # infer the added player's real team 
                 stats_df = get_stats(dnp, ask_matches=False)
                 team = stats_df.query(f'SEASON == {year-1}-{year}').head(1)['TEAM']
-                new_row['TEAM'] = team
+                new_row = {'PLAYER': dnp, 'TEAM': team}
                 # set players allstar team from regexp
                 res[as_team] = res[as_team].append(new_row, ignore_index=True)
         return res 

--- a/basketball_reference_scraper/box_scores.py
+++ b/basketball_reference_scraper/box_scores.py
@@ -2,11 +2,14 @@ import pandas as pd
 from requests import get
 from bs4 import BeautifulSoup
 from datetime import datetime
+import re
 
 try:
     from utils import get_game_suffix, remove_accents
+    from players import get_stats 
 except:
     from basketball_reference_scraper.utils import get_game_suffix, remove_accents
+    from basketball_reference_scraper.players import get_stats
 
 def get_box_scores(date, team1, team2, period='GAME', stat_type='BASIC'):
     date = pd.to_datetime(date)
@@ -31,3 +34,57 @@ def get_box_scores(date, team1, team2, period='GAME', stat_type='BASIC'):
         reserve_index = df2[df2['PLAYER']=='Reserves'].index[0]
         df2 = df2.drop(reserve_index).reset_index().drop('index', axis=1)
         return {team1: df1, team2: df2}
+
+def get_all_star_box_score(year: int):
+    """ Returns box star for all star game in a given year
+
+    Args:
+        year (int): the year of the all star game 
+
+    Raises:
+        ValueError: if invalid year is intered 
+        ConnectionError: when server cannot be reached
+
+    Returns:
+        dict: dictionary containing entries (team name, box score dataframe) for each team 
+    """
+    if year >= datetime.now().year or year < 1951:
+        raise ValueError('Please enter a valid year')
+    r = get(f'https://www.basketball-reference.com/allstar/NBA_{year}.html')
+    if r.status_code == 200:
+        dfs = []
+        soup = BeautifulSoup(r.content, 'html.parser')
+        team_names = list(map(lambda el: el.text, soup.select('div.section_heading > h2')[1:3]))
+        for table in soup.find_all('table')[1:3]:
+            df = pd.read_html(str(table))[0]
+            df.columns = list(map(lambda x: x[1], list(df.columns)))
+            df.rename(columns = {'Starters': 'PLAYER', 'Tm': 'TEAM'}, inplace=True)
+            reserve_index = df[df['PLAYER']=='Reserves'].index[0]
+            df = df.drop(reserve_index).reset_index().drop('index', axis=1) 
+            #drop team totals row (always last), totals row
+            totals_index = df[df['MP'] == 'Totals'].index[0]
+            df = df.drop(totals_index).reset_index().drop('index', axis=1) 
+            df = df.drop(df.tail(1).index).reset_index().drop('index', axis=1) 
+            # sometimes there is a nan player
+            dfs.append(df)
+        res = {team_names[0]: dfs[0], team_names[1]: dfs[1]}
+        # add DNPs for all-star roster purposes
+        # the all-star team each dnp is on is in parens. for some reasons this captures parens
+        dnp_allstar_teams = re.findall(r'\((.*?)\)', soup.select('ul.page_index > li > div')[0].text)
+        for i, dnp in enumerate(map(lambda el: el.text, soup.select('ul.page_index > li > div > a'))):
+            # check if the player is already in the dataframe because sometimes replacements are
+            # listed twice (e.g. 1980)
+            as_team = dnp_allstar_teams[i]
+            if dnp not in res[as_team]['PLAYER'].values:
+                new_row = {col: 0 for col in df.columns if col != 'PLAYER' and col != 'TEAM'}
+                new_row['PLAYER'] = dnp
+                # infer the added player's real team 
+                stats_df = get_stats(dnp, ask_matches=False)
+                team = stats_df.query(f'SEASON == {year-1}-{year}').head(1)['TEAM']
+                new_row['TEAM'] = team
+                # set players allstar team from regexp
+                res[as_team] = res[as_team].append(new_row, ignore_index=True)
+        return res 
+    else:
+        raise ConnectionError('Request to basketball reference failed')
+

--- a/basketball_reference_scraper/box_scores.py
+++ b/basketball_reference_scraper/box_scores.py
@@ -86,7 +86,7 @@ def get_all_star_box_score(year: int):
             if dnp not in res[as_team]['PLAYER'].values:
                 # infer the added player's real team 
                 stats_df = get_stats(dnp, ask_matches=False)
-                team = stats_df.query(f'SEASON == {year-1}-{year}').head(1)['TEAM']
+                team = stats_df[stats_df['SEASON'] == f'{year-1}-{str(year)[-2:]}'].head(1)['TEAM'].values[0]
                 new_row = {'PLAYER': dnp, 'TEAM': team}
                 # set players allstar team from regexp
                 res[as_team] = res[as_team].append(new_row, ignore_index=True)

--- a/basketball_reference_scraper/lookup.py
+++ b/basketball_reference_scraper/lookup.py
@@ -51,8 +51,9 @@ def lookup(player, ask_matches = True):
     """
     if len(matches) == 1 or ask_matches == False:
         matches.sort(key=lambda tup: tup[1])
-        print("You searched for \"{}\"\n{} result found.\n{}".format(player, len(matches), matches[0][0]))
-        print("Results for {}:\n".format(matches[0][0]))
+        if ask_matches:
+            print("You searched for \"{}\"\n{} result found.\n{}".format(player, len(matches), matches[0][0]))
+            print("Results for {}:\n".format(matches[0][0]))
         return matches[0][0]
 
     elif len(matches) > 1:

--- a/test/test_box_scores.py
+++ b/test/test_box_scores.py
@@ -1,5 +1,5 @@
 import unittest
-from basketball_reference_scraper.box_scores import get_box_scores 
+from basketball_reference_scraper.box_scores import get_box_scores, get_all_star_box_score 
 
 class TestBoxScores(unittest.TestCase):
     def test_get_box_scores(self):
@@ -9,6 +9,27 @@ class TestBoxScores(unittest.TestCase):
         df = d['DEN']
         expected_columns = ['PLAYER', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS', '+/-']
         self.assertListEqual(list(df.columns), expected_columns)
+
+    def test_get_all_star_box_score(self):
+        d = get_all_star_box_score(2020)
+        df = d['Team LeBron']
+        # they dont record +/- in ASG :(
+        expected_columns = ['PLAYER', 'TEAM', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
+        for item in df.columns:
+            if item not in expected_columns:
+                print(item) 
+        self.assertSetEqual(set(df.columns), set(expected_columns))
+
+        # check for one of the dnp players
+        self.assertTrue('Damian Lillard' in df['PLAYER'].values)
+        d2 = get_all_star_box_score(1980)
+        df = d2['East']
+        # check uniqueness of all star names
+        expected_players = ['George Gervin', 'Eddie Johnson', 'Moses Malone', 'Julius Erving', 'John Drew', 'Elvin Hayes', 'Dan Roundfield', 'Larry Bird', 'Tiny Archibald', 'Bill Cartwright', 'Micheal Ray Richardson', 'Dave Cowens']
+        for player in df['PLAYER'].values:
+            if player not in df['PLAYER'].values:
+                print(player)
+        self.assertListEqual(expected_players, list(df['PLAYER'].values))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_box_scores.py
+++ b/test/test_box_scores.py
@@ -19,6 +19,8 @@ class TestBoxScores(unittest.TestCase):
 
         # check for one of the dnp players
         self.assertTrue('Damian Lillard' in df['PLAYER'].values)
+        # make sure his team is right
+        self.assertTrue('POR' in df['TEAM'].values)
 
         d2 = get_all_star_box_score(1980)
         df = d2['East']

--- a/test/test_box_scores.py
+++ b/test/test_box_scores.py
@@ -15,13 +15,11 @@ class TestBoxScores(unittest.TestCase):
         df = d['Team LeBron']
         # they dont record +/- in ASG :(
         expected_columns = ['PLAYER', 'TEAM', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
-        for item in df.columns:
-            if item not in expected_columns:
-                print(item) 
         self.assertSetEqual(set(df.columns), set(expected_columns))
 
         # check for one of the dnp players
         self.assertTrue('Damian Lillard' in df['PLAYER'].values)
+
         d2 = get_all_star_box_score(1980)
         df = d2['East']
         # check uniqueness of all star names

--- a/test/test_box_scores.py
+++ b/test/test_box_scores.py
@@ -26,9 +26,6 @@ class TestBoxScores(unittest.TestCase):
         df = d2['East']
         # check uniqueness of all star names
         expected_players = ['George Gervin', 'Eddie Johnson', 'Moses Malone', 'Julius Erving', 'John Drew', 'Elvin Hayes', 'Dan Roundfield', 'Larry Bird', 'Tiny Archibald', 'Bill Cartwright', 'Micheal Ray Richardson', 'Dave Cowens']
-        for player in df['PLAYER'].values:
-            if player not in df['PLAYER'].values:
-                print(player)
         self.assertListEqual(expected_players, list(df['PLAYER'].values))
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have a project where I'm trying to give live predictions for the NBA All Star roster, and I figured I'd take the code I copy-pasted for scraping the roster and the box score, revise and refactor it, and throw it in here so I can depend on this awesome package and everyone can make use of it.

When a player is replaced from the ASG, the ASG stats are set to NAN, but the player name and team are still included so that projects using all-star status for classification can still use the `get_all_star_box_score` method for rosters. 

- Added and documented a method for getting the all star game box score for a given year
- Added test cases for the all star game roster including some edge cases (all passing right now)
- Refactored existing box score code for brevity and to minimize code reuse
- Changed the `get_stats` method so that it doesn't print to `STDOUT` when `ask_matches == False` so that it doesn't spam people when I use it to figure out an injured player's team. 