### PR TITLE
Fix lookup error for players with suffix number greater than 1

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -20,4 +20,4 @@ jobs:
       run: pip install -r requirements.txt 
     - name: Test
       run: python -m unittest discover test
-    - uses: codecov/codecov-action@v2
+

--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 6
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: pip install -r requirements.txt 
+    - name: Test
+      run: python -m unittest discover test
+    - uses: codecov/codecov-action@v2

--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 6
       matrix:

--- a/basketball_reference_scraper/utils.py
+++ b/basketball_reference_scraper/utils.py
@@ -85,10 +85,19 @@ def get_player_suffix(name):
                 page_first_name = page_names[0]
                 if first_name.lower() == page_first_name.lower():
                     return suffix
-                other_names_search.pop(0)
-                last_name_part = create_last_name_part_of_suffix(other_names_search)
-                initial = last_name_part[0].lower()
-                suffix = '/players/'+initial+'/'+last_name_part+first_name_part+'01.html'
+                # if players have same first two letters of last name then just
+                # increment suffix
+                elif first_name.lower()[:2] == page_first_name.lower()[:2]:
+                    player_number = int(''.join(c for c in suffix if c.isdigit())) + 1
+                    if player_number < 10:
+                        player_number = f"0{str(player_number)}"
+                    suffix = f"/players/{initial}/{last_name_part}{first_name_part}{player_number}.html"
+                else:
+                    other_names_search.pop(0)
+                    last_name_part = create_last_name_part_of_suffix(other_names_search)
+                    initial = last_name_part[0].lower()
+                    suffix = '/players/'+initial+'/'+last_name_part+first_name_part+'01.html'
+
                 player_r = get(f'https://www.basketball-reference.com{suffix}')
 
     return None

--- a/test/test_box_scores.py
+++ b/test/test_box_scores.py
@@ -23,7 +23,8 @@ class TestBoxScores(unittest.TestCase):
         self.assertTrue('POR' in df['TEAM'].values)
 
         d = get_all_star_box_score(2012)
-        print(d)
+        df = d['East']
+        self.assertSetEqual(set(df.columns), set(expected_columns))
 
         d2 = get_all_star_box_score(1980)
         df = d2['East']

--- a/test/test_box_scores.py
+++ b/test/test_box_scores.py
@@ -22,6 +22,9 @@ class TestBoxScores(unittest.TestCase):
         # make sure his team is right
         self.assertTrue('POR' in df['TEAM'].values)
 
+        d = get_all_star_box_score(2012)
+        print(d)
+
         d2 = get_all_star_box_score(1980)
         df = d2['East']
         # check uniqueness of all star names

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -5,6 +5,8 @@ class TestPlayers(unittest.TestCase):
     def test_get_stats(self):
         expected_columns = ['SEASON', 'AGE', 'TEAM', 'LEAGUE', 'POS', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
         df = get_stats('Joe Johnson')
+        self.assertCountEqual(list(df.columns), expected_columns)
+
         df = get_stats('LaMarcus Aldridge') 
         self.assertCountEqual(list(df.columns), expected_columns)
 
@@ -24,6 +26,7 @@ class TestPlayers(unittest.TestCase):
 
     def test_get_player_headshot(self):
         expected_url = 'https://d2cwpp38twqe55.cloudfront.net/req/202006192/images/players/bryanko01.jpg'
+        
         url = get_player_headshot('Kobe Bryant')
         self.assertEqual(url, expected_url)
 

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -26,7 +26,6 @@ class TestPlayers(unittest.TestCase):
 
     def test_get_player_headshot(self):
         expected_url = 'https://d2cwpp38twqe55.cloudfront.net/req/202006192/images/players/bryanko01.jpg'
-        
         url = get_player_headshot('Kobe Bryant')
         self.assertEqual(url, expected_url)
 

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -4,6 +4,7 @@ from basketball_reference_scraper.players import get_stats, get_game_logs, get_p
 class TestPlayers(unittest.TestCase):
     def test_get_stats(self):
         expected_columns = ['SEASON', 'AGE', 'TEAM', 'LEAGUE', 'POS', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
+        df = get_stats('Joe Johnson')
         df = get_stats('LaMarcus Aldridge') 
         self.assertCountEqual(list(df.columns), expected_columns)
 


### PR DESCRIPTION
Closes https://github.com/vishaalagartha/basketball_reference_scraper/issues/70. I realized that the suffix code does not work for players with a suffix greater than 1. The comment in there says that it will increment the suffix number, but it never does. This means that for players with the same first two letters in their first names an same last names (e.g. Joe Johnson and John Johnson), only the player with the first career chronologically (in this case John Johnson) will be able to be found. 