### PR TITLE
Add `get_wrapper` to prevent 429 errors to prevent scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 
 .vscode
 env
+package_passwords.txt

--- a/API.md
+++ b/API.md
@@ -20,16 +20,18 @@ Returns:
     'NATIONALITY', 'EXPERIENCE', 'COLLEGE']
   ```
 
-### `get_team_stats(team, season_end_year, data_format='PER_GAME')`
+### `get_team_stats(team, season_end_year, data_format='TOTALS')`
 
 Parameters:
   - `team` - NBA team abbreviation (e.g. `'GSW'`, `'SAS'`)
   - `season_end_year` - Desired end year (e.g. `1988`, `2011`)
-  - `data_format` - One of `'TOTAL'|'PER_GAME'|'PER_POSS'`. Default value is `'PER_GAME'`
+  - `data_format` - One of `'TOTALS'|'PER_GAME'|'PER_MINUTE'|'RANK'|'YEAR/YEAR'`. Default value is `'TOTALS'`
 
 Returns:
 
   A Pandas Series containing the following indices:
+
+  **Note**: Ranks are per game (except for MP, which are total) and sorted descending (except for TOV and PF); opponents ranked are flipped; year/year calculations are also per game
 
   ```
   ['G', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'FT', 'FTA', 'FT%', 'ORB', 
@@ -37,20 +39,38 @@ Returns:
   ```
 
 
-### `get_opp_stats(team, season_end_year, data_format='PER_GAME')`
+### `get_opp_stats(team, season_end_year, data_format)`
 
 Parameters:
   - `team` - NBA team abbreviation (e.g. `'GSW'`, `'SAS'`)
   - `season_end_year` - Desired end year (e.g. `1988`, `2011`)
-  - `data_format` - One of `'TOTAL'|'PER_GAME'|'PER_POSS'`. Default value is `'PER_GAME'`
+  - `data_format` - One of `'TOTALS'|'PER_GAME'|'PER_MINUTE'|'RANK'|'YEAR/YEAR'`. Default value is `'TOTALS'`
 
 Returns:
 
   A Pandas Series containing the following indices:
 
+  **Note**: Ranks are per game (except for MP, which are total) and sorted descending (except for TOV and PF); opponents ranked are flipped; year/year calculations are also per game
+
   ```
   ['OPP_G', 'OPP_MP', 'OPP_FG', 'OPP_FGA', 'OPP_FG%', 'OPP_3P', 'OPP_3PA', 'OPP_3P%', 'OPP_2P', 'OPP_2PA', 'OPP_2P%', 'OPP_FT', 'OPP_FTA', 'OPP_FT%', 
   'OPP_ORB', 'OPP_DRB', 'OPP_TRB', 'OPP_AST', 'OPP_STL', 'OPP_BLK', 'OPP_TOV', 'OPP_PF', 'OPP_PTS']
+  ```
+
+### `get_team_misc(team, season, data_format)`
+
+Parameters:
+  - `team` - NBA team abbreviation (e.g. `'GSW'`, `'SAS'`)
+  - `season_end_year` - Desired end year (e.g. `1988`, `2011`)
+  - `data_format` - One of `'TOTALS'|'RANK'`. Default value is `'TOTALS'`
+
+Returns:
+
+  A Pandas Series containing the following columns:
+
+  ```
+  ['W', 'L', 'PW', 'PL', 'MOV', 'SOS', 'SRS', 'ORtg', 'DRtg', 'Pace', 'FTr', '3PAr', 'eFG%', 'TOV%', 'ORB%', 
+  'FT/FGA', 'eFG%', 'TOV%', 'DRB%', 'FT/FGA', 'Arena', 'Attendance']
   ```
 
 ### `get_roster_stats(team, season, data_format='PER_GAME', playoffs=False)`
@@ -69,19 +89,19 @@ Returns:
   ['PLAYER', 'POS', 'AGE', 'TEAM', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS', 'SEASON']
   ```
 
-### `get_team_misc(team, season)`
+### `get_team_ratings(season, team=[])`
 
 Parameters:
-  - `team` - NBA team abbreviation (e.g. `'GSW'`, `'SAS'`)
-  - `season_end_year` - Desired end year (e.g. `1988`, `2011`)
+  - `season` - Desired end year (e.g. `1988`, `2011`)
+  - `team` - NBA team abbreviation (e.g. `'GSW'`, `'SAS'`), list of abbreviations (e.g. `['GSW'`, `'SAS']`), or empty list (indicating all team ratings). Default value is `[]`.
 
 Returns:
 
-  A Pandas Series containing the following columns:
+  A Pandas Dataframe containing the following columns:
 
   ```
-  ['W', 'L', 'PW', 'PL', 'MOV', 'SOS', 'SRS', 'ORtg', 'DRtg', 'Pace', 'FTr', '3PAr', 'eFG%', 'TOV%', 'ORB%', 
-  'FT/FGA', 'eFG%', 'TOV%', 'DRB%', 'FT/FGA', 'Arena', 'Attendance']
+  ['RK', 'TEAM', 'CONF', 'DIV', 'W', 'L', 'W/L%', 'MOV', 'ORTG', 'DRTG',
+        'NRTG', 'MOV/A', 'ORTG/A', 'DRTG/A', 'NRTG/A']
   ```
 
 ## Players

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # basketball_reference_scraper
 
-[Basketball Reference](https://www.basketball-reference.com/) is a great resource to aggregate statistics on NBA teams, seasons, players, and games. This package provides methods to acquire data for all these categories in pre-parsed and simplified formats.
+[Basketball Reference](https://www.basketball-reference.com/) is a resource to aggregate statistics on NBA teams, seasons, players, and games. This package provides methods to acquire data for all these categories in pre-parsed and simplified formats.
 
 ## Installing
 ### Via `pip`
@@ -14,9 +14,15 @@ pip install basketball-reference-scraper
 ### Via GitHub
 Alternatively, you can just clone this repo and import the libraries at your own discretion.
 
+### Selenium
+
+This package can also capture dynamically rendered content that is being added to the page via JavaScript, rather than baked into the HTML. To achieve this, it uses [Python Selenium](https://selenium-python.readthedocs.io/). Please refer to their [installation instructions](https://selenium-python.readthedocs.io/installation.html) and ensure you have [Chrome webdriver](https://selenium-python.readthedocs.io/installation.html#drivers) installed in and in your `PATH` variable.
+
 ## Wait, don't scrapers like this already exist?
 
 Yes, scrapers and APIs do exist. The primary API used currently is for [stats.nba.com](https://stats.nba.com/), but the website blocks too many requests, hindering those who want to acquire a lot of data. Additionally, scrapers for [Basketball Reference](https://www.basketball-reference.com/) do exist, but none of them load dynamically rendered content. These scrapers can only acquire statically loaded content, preventing those who want statistics in certain formats (for example, Player Advanced Stats Per Game).
+
+Most of the scrapers use outdated methodologies of scraping from `'https://widgets.sports-reference.com/'`. This is outdated and Basketball Reference no longer acquires their data from there. Additionally, [Sports Reference recently instituted a rate limiter](https://www.sports-reference.com/bot-traffic.html) preventing users from making an excess of 20 requests/minute. This package abstracts the waiting logic to ensure you never hit this threshold.
 
 ### API
 Currently, the package contains 5 modules: `teams`, `players`, `seasons`, `box_scores`, `pbp`, `shot_charts`, and `injury_report`. 

--- a/basketball_reference_scraper/box_scores.py
+++ b/basketball_reference_scraper/box_scores.py
@@ -8,15 +8,17 @@ import re
 try:
     from utils import get_game_suffix, remove_accents
     from players import get_stats 
+    from request_utils import get_wrapper
 except:
     from basketball_reference_scraper.utils import get_game_suffix, remove_accents
     from basketball_reference_scraper.players import get_stats
+    from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_box_scores(date, team1, team2, period='GAME', stat_type='BASIC'):
     date = pd.to_datetime(date)
     suffix = get_game_suffix(date, team1, team2).replace('/', '%2F')
-    r1 = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_box-{team1}-{period.lower()}-{stat_type.lower()}')
-    r2 = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_box-{team2}-{period.lower()}-{stat_type.lower()}')
+    r1 = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_box-{team1}-{period.lower()}-{stat_type.lower()}')
+    r2 = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_box-{team2}-{period.lower()}-{stat_type.lower()}')
     dfs = []
     if r1.status_code==200 and r2.status_code==200:
         for rq in (r1, r2):
@@ -64,7 +66,7 @@ def get_all_star_box_score(year: int):
     """
     if year >= datetime.now().year or year < 1951:
         raise ValueError('Please enter a valid year')
-    r = get(f'https://www.basketball-reference.com/allstar/NBA_{year}.html')
+    r = get_wrapper(f'https://www.basketball-reference.com/allstar/NBA_{year}.html')
     if r.status_code == 200:
         dfs = []
         soup = BeautifulSoup(r.content, 'html.parser')

--- a/basketball_reference_scraper/drafts.py
+++ b/basketball_reference_scraper/drafts.py
@@ -1,9 +1,9 @@
 import pandas as pd
-from requests import get
+
 from bs4 import BeautifulSoup
 
 def get_draft_class(year):
-      r = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fdraft%2FNBA_{year}.html&div=div_stats')
+      r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fdraft%2FNBA_{year}.html&div=div_stats')
       df = None
 
       if r.status_code==200:

--- a/basketball_reference_scraper/drafts.py
+++ b/basketball_reference_scraper/drafts.py
@@ -1,12 +1,16 @@
 import pandas as pd
-
 from bs4 import BeautifulSoup
+try:
+    from request_utils import get_wrapper
+except:
+    from basketball_reference_scraper.request_utils import get_wrapper
+
 
 def get_draft_class(year):
-      r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fdraft%2FNBA_{year}.html&div=div_stats')
-      df = None
+    r = get_wrapper(f'https://www.basketball-reference.com/draft/NBA_{year}.html')
 
-      if r.status_code==200:
+
+    if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table')
         df = pd.read_html(str(table))[0]
@@ -26,3 +30,5 @@ def get_draft_class(year):
         df = df[~df['PLAYER'].str.contains('Round|Player')]
 
         return df
+    else:
+        raise ConnectionError('Request to basketball reference failed')

--- a/basketball_reference_scraper/injury_report.py
+++ b/basketball_reference_scraper/injury_report.py
@@ -10,15 +10,18 @@ except:
     from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_injury_report():
-    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Ffriv%2Finjuries.fcgi&div=div_injuries')
+    r = get_wrapper(f'https://www.basketball-reference.com/friv/injuries.fcgi')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table')
         df = pd.read_html(str(table))[0]
         df.rename(columns = {'Player': 'PLAYER', 'Team': 'TEAM', 'Update': 'DATE', 'Description': 'DESCRIPTION'}, inplace=True)
+        df = df[df['PLAYER'] != 'Player']
         df['TEAM'] = df['TEAM'].apply(lambda x: TEAM_TO_TEAM_ABBR[x.upper()])
         df['DATE'] = df['DATE'].apply(lambda x: pd.to_datetime(x))
         df['STATUS'] = df['DESCRIPTION'].apply(lambda x: x[:x.index('(')].strip())
         df['INJURY'] = df['DESCRIPTION'].apply(lambda x: x[x.index('(')+1:x.index(')')].strip())
         df['DESCRIPTION'] = df['DESCRIPTION'].apply(lambda x: x[x.index('-')+2:].strip())
         return df
+    else:
+        raise ConnectionError('Request to basketball reference failed')

--- a/basketball_reference_scraper/injury_report.py
+++ b/basketball_reference_scraper/injury_report.py
@@ -4,11 +4,13 @@ from bs4 import BeautifulSoup
 
 try:
     from constants import TEAM_TO_TEAM_ABBR
+    from request_utils import get_wrapper
 except:
     from basketball_reference_scraper.constants import TEAM_TO_TEAM_ABBR
+    from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_injury_report():
-    r = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Ffriv%2Finjuries.fcgi&div=div_injuries')
+    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Ffriv%2Finjuries.fcgi&div=div_injuries')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table')

--- a/basketball_reference_scraper/pbp.py
+++ b/basketball_reference_scraper/pbp.py
@@ -5,12 +5,14 @@ from datetime import datetime
 
 try:
     from utils import get_game_suffix
+    from request_utils import get_wrapper
 except:
     from basketball_reference_scraper.utils import get_game_suffix
+    from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_pbp_helper(suffix):
     selector = f'#pbp'
-    r = get(f'https://www.basketball-reference.com/boxscores/pbp{suffix}')
+    r = get_wrapper(f'https://www.basketball-reference.com/boxscores/pbp{suffix}')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table', attrs={'id': 'pbp'})

--- a/basketball_reference_scraper/pbp.py
+++ b/basketball_reference_scraper/pbp.py
@@ -17,6 +17,8 @@ def get_pbp_helper(suffix):
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table', attrs={'id': 'pbp'})
         return pd.read_html(str(table))[0]
+    else:
+        raise ConnectionError('Request to basketball reference failed')
 
 def format_df(df1):
     df1.columns = list(map(lambda x: x[1], list(df1.columns)))

--- a/basketball_reference_scraper/players.py
+++ b/basketball_reference_scraper/players.py
@@ -5,69 +5,67 @@ from bs4 import BeautifulSoup
 try:
     from utils import get_player_suffix
     from lookup import lookup
-    from request_utils import get_wrapper
+    from request_utils import get_selenium_wrapper
 except:
     from basketball_reference_scraper.utils import get_player_suffix
-    from basketball_reference_scraper.request_utils import get_wrapper
+    from basketball_reference_scraper.request_utils import get_wrapper, get_selenium_wrapper
     from basketball_reference_scraper.lookup import lookup
 
 def get_stats(_name, stat_type='PER_GAME', playoffs=False, career=False, ask_matches = True):
     name = lookup(_name, ask_matches)
     suffix = get_player_suffix(name)
-    if suffix:
-        suffix = suffix.replace('/', '%2F')
-    else:
+    if not suffix:
         return pd.DataFrame()
-    selector = stat_type.lower()
+    stat_type = stat_type.lower()
     if playoffs:
-        selector = 'playoffs_'+selector
-    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_{selector}')
-    if r.status_code==200:
-        soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
-        if table is None:
-            return pd.DataFrame()
-        df = pd.read_html(str(table))[0]
-        df.rename(columns={'Season': 'SEASON', 'Age': 'AGE',
-                  'Tm': 'TEAM', 'Lg': 'LEAGUE', 'Pos': 'POS'}, inplace=True)
-        if 'FG.1' in df.columns:
-            df.rename(columns={'FG.1': 'FG%'}, inplace=True)
-        if 'eFG' in df.columns:
-            df.rename(columns={'eFG': 'eFG%'}, inplace=True)
-        if 'FT.1' in df.columns:
-            df.rename(columns={'FT.1': 'FT%'}, inplace=True)
+        xpath = f"//table[@id='playoffs_{stat_type}']"
+    else:
+        xpath = f"//table[@id='{stat_type}']"
+    table = get_selenium_wrapper(f'https://www.basketball-reference.com/{suffix}', xpath)
+    if table is None:
+        return pd.DataFrame()
+    df = pd.read_html(table)[0]
+    df.rename(columns={'Season': 'SEASON', 'Age': 'AGE',
+                'Tm': 'TEAM', 'Lg': 'LEAGUE', 'Pos': 'POS', 'Awards': 'AWARDS'}, inplace=True)
+    if 'FG.1' in df.columns:
+        df.rename(columns={'FG.1': 'FG%'}, inplace=True)
+    if 'eFG' in df.columns:
+        df.rename(columns={'eFG': 'eFG%'}, inplace=True)
+    if 'FT.1' in df.columns:
+        df.rename(columns={'FT.1': 'FT%'}, inplace=True)
 
-        career_index = df[df['SEASON']=='Career'].index[0]
-        if career:
-            df = df.iloc[career_index+2:, :]
-        else:
-            df = df.iloc[:career_index, :]
+    career_index = df[df['SEASON']=='Career'].index[0]
+    if career:
+        df = df.iloc[career_index+2:, :]
+    else:
+        df = df.iloc[:career_index, :]
 
-        df = df.reset_index().drop('index', axis=1)
-        return df
+    df = df.reset_index().drop('index', axis=1)
+    return df
 
 
 def get_game_logs(_name, year, playoffs=False, ask_matches=True):
     name = lookup(_name, ask_matches)
-    suffix = get_player_suffix(name).replace('/', '%2F').replace('.html', '')
+    suffix = get_player_suffix(name).replace('.html', '')
     if playoffs:
-        selector = 'div_pgl_basic_playoffs'
+        xpath = f"//table[@id='pgl_basic_playoffs']"
+        url = f'https://www.basketball-reference.com/{suffix}/gamelog-playoffs'
     else:
-        selector = 'div_pgl_basic'
-    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}%2Fgamelog%2F{year}%2F&div={selector}')
-    if r.status_code==200:
-        soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
-        if table:
-            df = pd.read_html(str(table))[0]
-            df.rename(columns = {'Date': 'DATE', 'Age': 'AGE', 'Tm': 'TEAM', 'Unnamed: 5': 'HOME/AWAY', 'Opp': 'OPPONENT',
-                'Unnamed: 7': 'RESULT', 'GmSc': 'GAME_SCORE'}, inplace=True)
-            df['HOME/AWAY'] = df['HOME/AWAY'].apply(lambda x: 'AWAY' if x=='@' else 'HOME')
-            df = df[df['Rk']!='Rk']
-            df = df.drop(['Rk', 'G'], axis=1)
-            df['DATE'] = pd.to_datetime(df['DATE'])
-            df = df[df['GS'] == '1'].reset_index(drop=True)          
-            return df
+        xpath = f"//table[@id='pgl_basic']"
+        url = f'https://www.basketball-reference.com/{suffix}/gamelog/{year}'
+    table = get_selenium_wrapper(url, xpath)
+    if not table:
+        return pd.DataFrame([])
+    df = pd.read_html(table)[0]
+    df.rename(columns = {'Date': 'DATE', 'Age': 'AGE', 'Tm': 'TEAM', 'Unnamed: 5': 'HOME/AWAY', 'Opp': 'OPPONENT',
+        'Unnamed: 7': 'RESULT', 'GmSc': 'GAME_SCORE', 'Series': 'SERIES' }, inplace=True)
+    df['HOME/AWAY'] = df['HOME/AWAY'].apply(lambda x: 'AWAY' if x=='@' else 'HOME')
+    df = df[df['Rk']!='Rk']
+    df = df.drop(['Rk', 'G'], axis=1).reset_index(drop=True)
+    if not playoffs:
+        df['DATE'] = pd.to_datetime(df['DATE'])
+    #df = df[df['GS'] == '1'].reset_index(drop=True)          
+    return df
 
 def get_player_headshot(_name, ask_matches=True):
     name = lookup(_name, ask_matches)

--- a/basketball_reference_scraper/players.py
+++ b/basketball_reference_scraper/players.py
@@ -5,8 +5,10 @@ from bs4 import BeautifulSoup
 try:
     from utils import get_player_suffix
     from lookup import lookup
+    from request_utils import get_wrapper
 except:
     from basketball_reference_scraper.utils import get_player_suffix
+    from basketball_reference_scraper.request_utils import get_wrapper
     from basketball_reference_scraper.lookup import lookup
 
 def get_stats(_name, stat_type='PER_GAME', playoffs=False, career=False, ask_matches = True):
@@ -19,7 +21,7 @@ def get_stats(_name, stat_type='PER_GAME', playoffs=False, career=False, ask_mat
     selector = stat_type.lower()
     if playoffs:
         selector = 'playoffs_'+selector
-    r = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_{selector}')
+    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}&div=div_{selector}')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table')
@@ -52,7 +54,7 @@ def get_game_logs(_name, year, playoffs=False, ask_matches=True):
         selector = 'div_pgl_basic_playoffs'
     else:
         selector = 'div_pgl_basic'
-    r = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}%2Fgamelog%2F{year}%2F&div={selector}')
+    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url={suffix}%2Fgamelog%2F{year}%2F&div={selector}')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table')

--- a/basketball_reference_scraper/request_utils.py
+++ b/basketball_reference_scraper/request_utils.py
@@ -1,0 +1,16 @@
+from requests import get
+from time import sleep
+
+def get_wrapper(url):
+    r = get(url)
+    while True:
+        if r.status_code == 200:
+            return r
+        elif r.status_code == 429:
+            retry_time = int(r.headers["Retry-After"])
+            print(f'Retrying after {retry_time} sec...')
+            sleep(retry_time)
+        else:
+            return r
+    
+        

--- a/basketball_reference_scraper/request_utils.py
+++ b/basketball_reference_scraper/request_utils.py
@@ -1,5 +1,23 @@
 from requests import get
-from time import sleep
+from time import sleep, time
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+
+options = Options()
+options.add_argument('--headless=new')
+driver = webdriver.Chrome(options=options)
+
+def get_selenium_wrapper(url, xpath, clickable_xpath=None):
+    try:
+        driver.get(url)
+        element = driver.find_element(By.XPATH, xpath)
+        return f'<table>{element.get_attribute("innerHTML")}</table>'
+    except:
+        print('Error obtaining data table.')
+        return None
 
 def get_wrapper(url):
     r = get(url)

--- a/basketball_reference_scraper/request_utils.py
+++ b/basketball_reference_scraper/request_utils.py
@@ -9,8 +9,14 @@ from selenium.webdriver.common.by import By
 options = Options()
 options.add_argument('--headless=new')
 driver = webdriver.Chrome(options=options)
+last_request = time()
 
-def get_selenium_wrapper(url, xpath, clickable_xpath=None):
+def get_selenium_wrapper(url, xpath):
+    global last_request
+    # Verify last request was 3 seconds ago
+    if 0 < time() - last_request < 3:
+        sleep(3)
+    last_request = time()
     try:
         driver.get(url)
         element = driver.find_element(By.XPATH, xpath)
@@ -20,6 +26,11 @@ def get_selenium_wrapper(url, xpath, clickable_xpath=None):
         return None
 
 def get_wrapper(url):
+    global last_request
+    # Verify last request was 3 seconds ago
+    if 0 < time() - last_request < 3:
+        sleep(3)
+    last_request = time()
     r = get(url)
     while True:
         if r.status_code == 200:
@@ -30,5 +41,3 @@ def get_wrapper(url):
             sleep(retry_time)
         else:
             return r
-    
-        

--- a/basketball_reference_scraper/seasons.py
+++ b/basketball_reference_scraper/seasons.py
@@ -3,6 +3,12 @@ from datetime import datetime
 from requests import get
 from bs4 import BeautifulSoup
 
+try:
+    from request_utils import get_wrapper
+except:
+    from basketball_reference_scraper.request_utils import get_wrapper
+
+
 def get_schedule(season, playoffs=False):
     months = ['October', 'November', 'December', 'January', 'February', 'March',
             'April', 'May', 'June']
@@ -11,7 +17,7 @@ def get_schedule(season, playoffs=False):
                 'July', 'August', 'September', 'October-2020']
     df = pd.DataFrame()
     for month in months:
-        r = get(f'https://www.basketball-reference.com/leagues/NBA_{season}_games-{month.lower()}.html')
+        r = get_wrapper(f'https://www.basketball-reference.com/leagues/NBA_{season}_games-{month.lower()}.html')
         if r.status_code==200:
             soup = BeautifulSoup(r.content, 'html.parser')
             table = soup.find('table', attrs={'id': 'schedule'})
@@ -66,7 +72,7 @@ def get_standings(date=None):
     else:
         date = pd.to_datetime(date)
     d = {}
-    r = get(f'https://www.basketball-reference.com/friv/standings.fcgi?month={date.month}&day={date.day}&year={date.year}')
+    r = get_wrapper(f'https://www.basketball-reference.com/friv/standings.fcgi?month={date.month}&day={date.day}&year={date.year}')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         e_table = soup.find('table', attrs={'id': 'standings_e'})

--- a/basketball_reference_scraper/seasons.py
+++ b/basketball_reference_scraper/seasons.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from datetime import datetime
-from requests import get
 from bs4 import BeautifulSoup
 
 try:
@@ -86,4 +85,6 @@ def get_standings(date=None):
             w_df.rename(columns={'Western Conference': 'TEAM'}, inplace=True)
         d['EASTERN_CONF'] = e_df
         d['WESTERN_CONF'] = w_df
-    return d
+        return d
+    else:
+        raise ConnectionError('Request to basketball reference failed')

--- a/basketball_reference_scraper/shot_charts.py
+++ b/basketball_reference_scraper/shot_charts.py
@@ -6,8 +6,10 @@ import re
 
 try:
     from utils import get_game_suffix
+    from request_utils import get_wrapper
 except:
     from basketball_reference_scraper.utils import get_game_suffix
+    from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_location(s):
     l = s.split(';')
@@ -34,7 +36,7 @@ def get_description(s):
 def get_shot_chart(date, team1, team2):
     date = pd.to_datetime(date)
     suffix = get_game_suffix(date, team1, team2).replace('/boxscores', '')
-    r = get(f'https://www.basketball-reference.com/boxscores/shot-chart{suffix}')
+    r = get_wrapper(f'https://www.basketball-reference.com/boxscores/shot-chart{suffix}')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         shot_chart1_div = soup.find('div', attrs={'id': f'shots-{team1}'})

--- a/basketball_reference_scraper/shot_charts.py
+++ b/basketball_reference_scraper/shot_charts.py
@@ -65,3 +65,5 @@ def get_shot_chart(date, team1, team2):
         df2 = df2.drop('index', axis=1)
 
         return {f'{team1}': df1, f'{team2}': df2}
+    else:
+        raise ConnectionError('Request to basketball reference failed')

--- a/basketball_reference_scraper/teams.py
+++ b/basketball_reference_scraper/teams.py
@@ -5,13 +5,14 @@ from bs4 import BeautifulSoup
 try:
     from constants import TEAM_TO_TEAM_ABBR, TEAM_SETS
     from utils import remove_accents
+    from request_utils import get_wrapper
 except:
     from basketball_reference_scraper.constants import TEAM_TO_TEAM_ABBR, TEAM_SETS
     from basketball_reference_scraper.utils import remove_accents
 
 
 def get_roster(team, season_end_year):
-    r = get(
+    r = get_wrapper(
         f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html')
     df = None
     if r.status_code == 200:
@@ -40,7 +41,7 @@ def get_team_stats(team, season_end_year, data_format='PER_GAME'):
         selector = 'div_per_game-team'
     elif data_format == 'PER_POSS':
         selector = 'div_per_poss-team'
-    r = get(
+    r = get_wrapper(
         f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}.html&div={selector}')
     df = None
     if r.status_code == 200:
@@ -64,7 +65,7 @@ def get_opp_stats(team, season_end_year, data_format='PER_GAME'):
         selector = 'div_per_game-opponent'
     elif data_format == 'PER_POSS':
         selector = 'div_per_poss-opponent'
-    r = get(
+    r = get_wrapper(
         f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}.html&div={selector}')
     df = None
     if r.status_code == 200:
@@ -84,7 +85,7 @@ def get_opp_stats(team, season_end_year, data_format='PER_GAME'):
 
 
 def get_team_misc(team, season_end_year):
-    r = get(
+    r = get_wrapper(
         f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}.html&div=div_advanced-team')
     df = None
     if r.status_code == 200:
@@ -111,7 +112,7 @@ def get_roster_stats(team: list, season_end_year: int, data_format='PER_GAME', p
     else:
         period = 'leagues'
     selector = data_format.lower()
-    r = get(
+    r = get_wrapper(
         f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2F{period}%2FNBA_{season_end_year}_{selector}.html&div=div_{selector}_stats')
     df = None
     possible_teams = [team]
@@ -137,7 +138,7 @@ def get_roster_stats(team: list, season_end_year: int, data_format='PER_GAME', p
 
 def get_team_ratings(*, team=[], season_end_year: int):
 
-    r = get(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}_ratings.html&div=div_ratings')
+    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}_ratings.html&div=div_ratings')
     if r.status_code == 200:
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table')

--- a/basketball_reference_scraper/teams.py
+++ b/basketball_reference_scraper/teams.py
@@ -1,14 +1,14 @@
 import pandas as pd
-from requests import get
 from bs4 import BeautifulSoup
 
 try:
     from constants import TEAM_TO_TEAM_ABBR, TEAM_SETS
     from utils import remove_accents
-    from request_utils import get_wrapper
+    from request_utils import get_wrapper, get_selenium_wrapper
 except:
     from basketball_reference_scraper.constants import TEAM_TO_TEAM_ABBR, TEAM_SETS
     from basketball_reference_scraper.utils import remove_accents
+    from basketball_reference_scraper.request_utils import get_wrapper, get_selenium_wrapper
 
 
 def get_roster(team, season_end_year):
@@ -17,7 +17,7 @@ def get_roster(team, season_end_year):
     df = None
     if r.status_code == 200:
         soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
+        table = soup.find('table', {'id': 'roster'})
         df = pd.read_html(str(table))[0]
         df.columns = ['NUMBER', 'PLAYER', 'POS', 'HEIGHT', 'WEIGHT', 'BIRTH_DATE',
                       'NATIONALITY', 'EXPERIENCE', 'COLLEGE']
@@ -34,123 +34,107 @@ def get_roster(team, season_end_year):
     return df
 
 
-def get_team_stats(team, season_end_year, data_format='PER_GAME'):
-    if data_format == 'TOTAL':
-        selector = 'div_totals-team'
+def get_team_stats(team, season_end_year, data_format='TOTALS'):
+    xpath = '//table[@id="team_and_opponent"]'
+    table = get_selenium_wrapper(f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html', xpath)
+    if not table:
+        raise ConnectionError('Request to basketball reference failed')
+    df = pd.read_html(table)[0]
+    opp_idx = df[df['Unnamed: 0'] == 'Opponent'].index[0]
+    df = df[:opp_idx]
+    if data_format == 'TOTALS':
+        row_idx = 'Team'
     elif data_format == 'PER_GAME':
-        selector = 'div_per_game-team'
-    elif data_format == 'PER_POSS':
-        selector = 'div_per_poss-team'
-    r = get_wrapper(
-        f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}.html&div={selector}')
-    df = None
-    if r.status_code == 200:
-        soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
-        df = pd.read_html(str(table))[0]
-        league_avg_index = df[df['Team'] == 'League Average'].index[0]
-        df = df[:league_avg_index]
-        df['Team'] = df['Team'].apply(lambda x: x.replace('*', '').upper())
-        df['TEAM'] = df['Team'].apply(lambda x: TEAM_TO_TEAM_ABBR[x])
-        df = df.drop(['Rk', 'Team'], axis=1)
-        df.loc[:, 'SEASON'] = f'{season_end_year-1}-{str(season_end_year)[2:]}'
-        s = df[df['TEAM'] == team]
-        return pd.Series(index=list(s.columns), data=s.values.tolist()[0])
+        row_idx = 'Team/G'
+    elif data_format == 'RANK':
+        row_idx = 'Lg Rank'
+    elif data_format == 'YEAR/YEAR':
+        row_idx = 'Year/Year'
+    else:
+        print('Invalid data format')
+        return pd.DataFrame()
+    
+    s = df[df['Unnamed: 0'] == row_idx]
+    s = s.drop(columns=['Unnamed: 0']).reindex()
+    return pd.Series(index=list(s.columns), data=s.values.tolist()[0])
 
 
 def get_opp_stats(team, season_end_year, data_format='PER_GAME'):
-    if data_format == 'TOTAL':
-        selector = 'div_totals-opponent'
+    xpath = '//table[@id="team_and_opponent"]'
+    table = get_selenium_wrapper(f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html', xpath)
+    if not table:
+        raise ConnectionError('Request to basketball reference failed')
+    df = pd.read_html(table)[0]
+    opp_idx = df[df['Unnamed: 0'] == 'Opponent'].index[0]
+    df = df[opp_idx:]
+    if data_format == 'TOTALS':
+        row_idx = 'Opponent'
     elif data_format == 'PER_GAME':
-        selector = 'div_per_game-opponent'
-    elif data_format == 'PER_POSS':
-        selector = 'div_per_poss-opponent'
-    r = get_wrapper(
-        f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}.html&div={selector}')
-    df = None
-    if r.status_code == 200:
-        soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
-        df = pd.read_html(str(table))[0]
-        league_avg_index = df[df['Team'] == 'League Average'].index[0]
-        df = df[:league_avg_index]
-        df['Team'] = df['Team'].apply(lambda x: x.replace('*', '').upper())
-        df['TEAM'] = df['Team'].apply(lambda x: TEAM_TO_TEAM_ABBR[x])
-        df = df.drop(['Rk', 'Team'], axis=1)
-        df.columns = list(map(lambda x: 'OPP_'+x, list(df.columns)))
-        df.rename(columns={'OPP_TEAM': 'TEAM'}, inplace=True)
-        df.loc[:, 'SEASON'] = f'{season_end_year-1}-{str(season_end_year)[2:]}'
-        s = df[df['TEAM'] == team]
-        return pd.Series(index=list(s.columns), data=s.values.tolist()[0])
+        row_idx = 'Opponent/G'
+    elif data_format == 'RANK':
+        row_idx = 'Lg Rank'
+    elif data_format == 'YEAR/YEAR':
+        row_idx = 'Year/Year'
+    else:
+        print('Invalid data format')
+        return pd.DataFrame()
+    
+    s = df[df['Unnamed: 0'] == row_idx]
+    s = s.drop(columns=['Unnamed: 0']).reindex()
+    return pd.Series(index=list(s.columns), data=s.values.tolist()[0])
 
 
-def get_team_misc(team, season_end_year):
-    r = get_wrapper(
-        f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}.html&div=div_advanced-team')
-    df = None
-    if r.status_code == 200:
-        soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
-        df = pd.read_html(str(table))[0]
-        df.columns = list(map(lambda x: x[1], list(df.columns)))
-        league_avg_index = df[df['Team'] == 'League Average'].index[0]
-        df = df[:league_avg_index]
-        df['Team'] = df['Team'].apply(lambda x: x.replace('*', '').upper())
-        df['TEAM'] = df['Team'].apply(lambda x: TEAM_TO_TEAM_ABBR[x])
-        df = df.drop(['Rk', 'Team'], axis=1)
-        df.rename(columns={'Age': 'AGE', 'Pace': 'PACE', 'Arena': 'ARENA',
-                  'Attend.': 'ATTENDANCE', 'Attend./G': 'ATTENDANCE/G'}, inplace=True)
-        df.loc[:, 'SEASON'] = f'{season_end_year-1}-{str(season_end_year)[2:]}'
-        s = df[df['TEAM'] == team]
-        s = s.loc[:, ~s.columns.str.contains('^Unnamed')]
-        return pd.Series(index=list(s.columns), data=s.values.tolist()[0])
-
+def get_team_misc(team, season_end_year, data_format='TOTALS'):
+    xpath = '//table[@id="team_misc"]'
+    table = get_selenium_wrapper(f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html', xpath)
+    if not table:
+        raise ConnectionError('Request to basketball reference failed')
+    df = pd.read_html(table)[0]
+    if data_format == 'TOTALS':
+        row_idx = 'Team'
+    elif data_format == 'RANK':
+        row_idx = 'Lg Rank'
+    else:
+        print('Invalid data format')
+        return pd.DataFrame()
+    df.columns = df.columns.droplevel()
+    df.rename(columns={'Arena': 'ARENA',
+                'Attendance': 'ATTENDANCE'}, inplace=True)
+    s = df[df['Unnamed: 0_level_1'] == row_idx]
+    s = s.drop(columns=['Unnamed: 0_level_1']).reindex()
+    return pd.Series(index=list(s.columns), data=s.values.tolist()[0])
 
 def get_roster_stats(team: list, season_end_year: int, data_format='PER_GAME', playoffs=False):
     if playoffs:
-        period = 'playoffs'
+        xpath=f'//table[@id="playoffs_{data_format.lower()}"]'
     else:
-        period = 'leagues'
-    selector = data_format.lower()
-    r = get_wrapper(
-        f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2F{period}%2FNBA_{season_end_year}_{selector}.html&div=div_{selector}_stats')
-    df = None
-    possible_teams = [team]
-    for s in TEAM_SETS:
-        if team in s:
-            possible_teams = s
-    if r.status_code == 200:
-        soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
-        df2 = pd.read_html(str(table))[0]
-        for index, row in df2.iterrows():
-            if row['Tm'] in possible_teams:
-                if df is None:
-                    df = pd.DataFrame(columns=list(row.index)+['SEASON'])
-                row['SEASON'] = f'{season_end_year-1}-{str(season_end_year)[2:]}'
-                df = df.append(row)
-        df.rename(columns={'Player': 'PLAYER', 'Age': 'AGE',
-                  'Tm': 'TEAM', 'Pos': 'POS'}, inplace=True)
-        df['PLAYER'] = df['PLAYER'].apply(
-            lambda name: remove_accents(name, team, season_end_year))
-        df = df.reset_index().drop(['Rk', 'index'], axis=1)
-        return df
+        xpath=f'//table[@id="{data_format.lower()}"]'
+    table = get_selenium_wrapper(
+        f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html', xpath)
+    if not table:
+        raise ConnectionError('Request to basketball reference failed')
+    df = pd.read_html(table)[0]
+    df.rename(columns={'Player': 'PLAYER', 'Age': 'AGE',
+                'Tm': 'TEAM', 'Pos': 'POS'}, inplace=True)
+    df['PLAYER'] = df['PLAYER'].apply(
+        lambda name: remove_accents(name, team, season_end_year))
+    df = df.reset_index().drop(['Rk', 'index'], axis=1)
+    return df
 
-def get_team_ratings(*, team=[], season_end_year: int):
-    # Scrape data from URL
-    r = get_wrapper(f'https://widgets.sports-reference.com/wg.fcgi?css=1&site=bbr&url=%2Fleagues%2FNBA_{season_end_year}_ratings.html&div=div_ratings')
+def get_team_ratings(season_end_year: int, team=[]):
+    r = get_wrapper(f'https://www.basketball-reference.com/leagues/NBA_{season_end_year}_ratings.html')
     if r.status_code == 200:
         soup = BeautifulSoup(r.content, 'html.parser')
-        table = soup.find('table')
+        table = soup.find('table', { 'id': 'ratings' })
+    
         df = pd.read_html(str(table))[0]
-
         # Clean columns and indexes
         df = df.droplevel(level=0, axis=1)
         
-        df.drop(columns=['Rk', 'Conf', 'Div', 'W', 'L', 'W/L%'], inplace=True)
         upper_cols = list(pd.Series(df.columns).apply(lambda x: x.upper()))
         df.columns = upper_cols
-
+        df.dropna(inplace=True)
+        df = df[df['RK'] != 'Rk']
         df['TEAM'] = df['TEAM'].apply(lambda x: x.upper())
         df['TEAM'] = df['TEAM'].apply(lambda x: TEAM_TO_TEAM_ABBR[x])
 
@@ -168,5 +152,7 @@ def get_team_ratings(*, team=[], season_end_year: int):
                 df = df[df['TEAM'].isin(list_team)]
             else:
                 df = df[df['TEAM'].isin(team)]
-                    
-    return df
+        df = df.reindex()
+        return df
+    else:
+        raise ConnectionError('Request to basketball reference failed')

--- a/basketball_reference_scraper/utils.py
+++ b/basketball_reference_scraper/utils.py
@@ -3,9 +3,13 @@ from bs4 import BeautifulSoup
 import pandas as pd
 import unicodedata, unidecode
 
+try:
+    from request_utils import get_wrapper
+except:
+    from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_game_suffix(date, team1, team2):
-    r = get(f'https://www.basketball-reference.com/boxscores/index.fcgi?year={date.year}&month={date.month}&day={date.day}')
+    r = get_wrapper(f'https://www.basketball-reference.com/boxscores/index.fcgi?year={date.year}&month={date.month}&day={date.day}')
     suffix = None
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
@@ -60,13 +64,13 @@ def get_player_suffix(name):
         other_names_search = other_names
         last_name_part = create_last_name_part_of_suffix(other_names)
         suffix = '/players/'+initial+'/'+last_name_part+first_name_part+'01.html'
-    player_r = get(f'https://www.basketball-reference.com{suffix}')
+    player_r = get_wrapper(f'https://www.basketball-reference.com{suffix}')
     while player_r.status_code == 404:
         other_names_search.pop(0)
         last_name_part = create_last_name_part_of_suffix(other_names_search)
         initial = last_name_part[0].lower()
         suffix = '/players/'+initial+'/'+last_name_part+first_name_part+'01.html'
-        player_r = get(f'https://www.basketball-reference.com{suffix}')
+        player_r = get_wrapper(f'https://www.basketball-reference.com{suffix}')
     while player_r.status_code==200:
         player_soup = BeautifulSoup(player_r.content, 'html.parser')
         h1 = player_soup.find('h1')
@@ -98,7 +102,7 @@ def get_player_suffix(name):
                     initial = last_name_part[0].lower()
                     suffix = '/players/'+initial+'/'+last_name_part+first_name_part+'01.html'
 
-                player_r = get(f'https://www.basketball-reference.com{suffix}')
+                player_r = get_wrapper(f'https://www.basketball-reference.com{suffix}')
 
     return None
 
@@ -107,7 +111,7 @@ def remove_accents(name, team, season_end_year):
     alphabet = set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY ')
     if len(set(name).difference(alphabet))==0:
         return name
-    r = get(f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html')
+    r = get_wrapper(f'https://www.basketball-reference.com/teams/{team}/{season_end_year}.html')
     team_df = None
     best_match = name
     if r.status_code==200:

--- a/basketball_reference_scraper/utils.py
+++ b/basketball_reference_scraper/utils.py
@@ -9,17 +9,15 @@ except:
     from basketball_reference_scraper.request_utils import get_wrapper
 
 def get_game_suffix(date, team1, team2):
-    r = get_wrapper(f'https://www.basketball-reference.com/boxscores/index.fcgi?year={date.year}&month={date.month}&day={date.day}')
-    suffix = None
+    r = get_wrapper(f'https://www.basketball-reference.com/boxscores/?month={date.month}&year={date.year}&day={date.day}')
     if r.status_code==200:
         soup = BeautifulSoup(r.content, 'html.parser')
         for table in soup.find_all('table', attrs={'class': 'teams'}):
             for anchor in table.find_all('a'):
                 if 'boxscores' in anchor.attrs['href']:
-                    if team1 in anchor.attrs['href'] or team2 in anchor.attrs['href']:
+                    if team1 in str(anchor.attrs['href']) or team2 in str(anchor.attrs['href']):
                         suffix = anchor.attrs['href']
-    return suffix
-
+                        return suffix
 """
     Helper function for inplace creation of suffixes--necessary in order
     to fetch rookies and other players who aren't in the /players

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="basketball_reference_scraper",
-    version="1.0.31",
+    version="2.0.0",
     author="Vishaal Agartha",
     author_email="vishaalagartha@gmail.com",
     license="MIT",
@@ -22,17 +22,18 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        'beautifulsoup4==4.8.2',
-        'bs4==0.0.1',
-        'lxml==4.6.5',
-        'numpy==1.21.0',
-        'pandas==1.3.1',
-        'python-dateutil==2.8.1',
-        'pytz==2019.3',
-        'requests==2.27.1',
-        'six==1.13.0',
-        'soupsieve==1.9.5',
-        'unidecode==1.2.0'
+        'beautifulsoup4',
+        'bs4',
+        'lxml',
+        'numpy',
+        'pandas',
+        'python-dateutil',
+        'pytz',
+        'requests',
+        'six',
+        'soupsieve',
+        'Unidecode',
+        'selenium'
     ],
     extras_require={
         'test': ['unittest'],

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -3,18 +3,19 @@ from basketball_reference_scraper.players import get_stats, get_game_logs, get_p
 
 class TestPlayers(unittest.TestCase):
     def test_get_stats(self):
-        expected_columns = ['SEASON', 'AGE', 'TEAM', 'LEAGUE', 'POS', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
+        expected_columns_season = ['SEASON', 'AGE', 'TEAM', 'LEAGUE', 'POS', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS', 'AWARDS']
+        expected_columns_playoffs = ['SEASON', 'AGE', 'TEAM', 'LEAGUE', 'POS', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
         df = get_stats('Joe Johnson')
-        self.assertCountEqual(list(df.columns), expected_columns)
+        self.assertCountEqual(list(df.columns), expected_columns_season)
 
         df = get_stats('LaMarcus Aldridge') 
-        self.assertCountEqual(list(df.columns), expected_columns)
+        self.assertCountEqual(list(df.columns), expected_columns_season)
 
         df = get_stats('LaMarcus Aldridge', career=True)
-        self.assertCountEqual(list(df.columns), expected_columns)
+        self.assertCountEqual(list(df.columns), expected_columns_season)
 
         df = get_stats('LaMarcus Aldridge', playoffs=True, career=True)
-        self.assertCountEqual(list(df.columns), expected_columns)
+        self.assertCountEqual(list(df.columns), expected_columns_playoffs)
 
     def test_get_game_logs(self):
         expected_columns = ['DATE', 'AGE', 'TEAM', 'HOME/AWAY', 'OPPONENT', 'RESULT', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS', 'GAME_SCORE', '+/-']
@@ -23,7 +24,7 @@ class TestPlayers(unittest.TestCase):
         self.assertCountEqual(list(df.columns), expected_columns)
 
         df = get_game_logs('Pau Gasol', 2010, playoffs=False)
-        self.assertEqual(len(df), 65)
+        self.assertEqual(len(df), 82)
 
     def test_get_player_headshot(self):
         expected_url = 'https://d2cwpp38twqe55.cloudfront.net/req/202006192/images/players/bryanko01.jpg'

--- a/test/test_teams.py
+++ b/test/test_teams.py
@@ -1,5 +1,5 @@
 import unittest
-from basketball_reference_scraper.teams import get_roster, get_team_stats, get_opp_stats, get_roster_stats, get_team_misc
+from basketball_reference_scraper.teams import get_roster, get_team_stats, get_opp_stats, get_roster_stats, get_team_misc, get_team_ratings
 
 class TestTeams(unittest.TestCase):
     def test_get_roster(self):
@@ -32,12 +32,12 @@ class TestTeams(unittest.TestCase):
 
     def test_get_roster_stats(self):
         df = get_roster_stats('GSW', 2019)
-        expected_columns = ['PLAYER', 'POS', 'AGE', 'TEAM', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS', 'SEASON']
+        expected_columns = ['PLAYER', 'AGE', 'G', 'GS', 'MP', 'FG', 'FGA', 'FG%', '3P', '3PA', '3P%', '2P', '2PA', '2P%', 'eFG%', 'FT', 'FTA', 'FT%', 'ORB', 'DRB', 'TRB', 'AST', 'STL', 'BLK', 'TOV', 'PF', 'PTS']
         self.assertCountEqual(list(df.columns), expected_columns)
 
     def test_get_team_misc(self):
         series = get_team_misc('GSW', 2019)
-        expected_indices = ['AGE', 'W', 'L', 'PW', 'PL', 'MOV', 'SOS', 'SRS', 'ORtg', 'DRtg', 'NRtg', 'PACE', 'FTr', '3PAr', 'TS%', 'eFG%', 'TOV%', 'ORB%', 'FT/FGA', 'eFG%', 'TOV%', 'DRB%', 'FT/FGA', 'ARENA', 'ATTENDANCE', 'ATTENDANCE/G', 'TEAM', 'SEASON']
+        expected_indices = ['W', 'L', 'PW', 'PL', 'MOV', 'SOS', 'SRS', 'ORtg', 'DRtg', 'Pace', 'FTr', '3PAr', 'eFG%', 'TOV%', 'ORB%', 'FT/FGA', 'eFG%', 'TOV%', 'DRB%', 'FT/FGA', 'ARENA', 'ATTENDANCE']
         self.assertCountEqual(list(series.index), expected_indices)
 
         series = get_team_misc('CHO', 2019)
@@ -46,8 +46,16 @@ class TestTeams(unittest.TestCase):
         series = get_team_misc('NOK', 2007)
         self.assertCountEqual(list(series.index), expected_indices)
 
-        series = get_team_misc('TCB', 1951)
-        self.assertCountEqual(list(series.index), expected_indices)
+    def test_get_team_ratings(self):
+        expected_columns = ['RK', 'SEASON', 'TEAM', 'CONF', 'DIV', 'W', 'L', 'W/L%', 'MOV', 'ORTG', 'DRTG', 'NRTG', 'MOV/A', 'ORTG/A', 'DRTG/A', 'NRTG/A']
+        
+        df = get_team_ratings(2019, ['BOS', 'GSW', 'DAL'])
+        self.assertCountEqual(list(df.columns), expected_columns)
+        self.assertEqual(len(df), 3)
+
+        df = get_team_ratings(2024)
+        self.assertCountEqual(list(df.columns), expected_columns)
+        self.assertEqual(len(df), 30)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[What]
Introduce `get_wrapper` to handle when there is a Retry-After in the response header. Allows scraping to continue after 429 errors

[How]
Add `sleep` functionality to pause execution.